### PR TITLE
create a synthetic mfrom when mfrom is empty

### DIFF
--- a/bin/spfd
+++ b/bin/spfd
@@ -261,9 +261,9 @@ and C<temperror>, respectively, in order to comply with RFC 4408 terminology.
 
 =item *
 
-SPF checks with an empty identity are no longer supported.  In the case of an
-empty C<MAIL FROM> SMTP transaction parameter, perform a check with the C<helo>
-scope directly.
+In the case of an empty C<MAIL FROM> SMTP transaction parameter (C<<
+MAIL FROM:<> >>), the identity checked will be postmaster@helo name as specified
+in RFC 7208.
 
 =back
 

--- a/bin/spfquery
+++ b/bin/spfquery
@@ -626,8 +626,10 @@ if (
     exit(255);
 }
 
-if (defined($identity) and $identity eq '') {
-    STDERR->print("Error: Empty identities are not supported. See spfquery(1).\n");
+if (defined($identity) and $identity eq '' and defined $helo_identity) {
+    $identity = 'postmaster@' . $helo_identity;
+} elsif (defined($identity) and $identity eq '') {
+    STDERR->print("Error: Empty identities are not supported without specifying HELO.\n");
     exit(255);
 }
 


### PR DESCRIPTION
When mfrom is empty, create a synthetic mfrom (postmaster@helo) and check that identity using
the mfrom scope as specified in RFC 7208