### PR TITLE
Tad 417 debian patches open spf.org deprecated

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,5 @@
 {{$NEXT}}
 
-3.20250331 2025-03-31 Australia/Melbourne
   Mail::SPF:
   - Redirecting all references to openspf.org to open-spf.org
 

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 {{$NEXT}}
 
+3.20250331 2025-03-31 Australia/Melbourne
+  Mail::SPF:
+  - Redirecting all references to openspf.org to open-spf.org
+
 3.20240923 2024-09-23 Australia/Melbourne
   - Fix issue where certain DNS results would cause an exception to be thrown
 

--- a/README
+++ b/README
@@ -7,10 +7,10 @@ Mail::SPF 3.20240617 -- A Perl implementation of the Sender Policy Framework
 Mail::SPF is an object-oriented Perl implementation of the Sender Policy
 Framework (SPF) e-mail sender authentication system.
 
-See <http://www.openspf.net> for more information about SPF.
+See <https://tools.ietf.org/html/rfc7208> for more information about SPF.
 
 This release of Mail::SPF fully conforms to RFC 4408 and passes the 2009.10
-release of the official test-suite <http://www.openspf.net/Test_Suite>.
+release of the official test-suite <http://www.open-spf.org/Test_Suite>.
 
 The Mail::SPF source package includes the following additional tools:
 

--- a/bin/spfd
+++ b/bin/spfd
@@ -196,9 +196,7 @@ breaks added for clarity):
     result=fail
     local_explanation=example.com: Sender is not authorized by default to use
         'user@example.com' in 'mfrom' identity (mechanism '-all' matched)
-    authority_explanation=Rejected by SPF record. Please see 
-        http://www.openspf.org/why.html?sender=user%40example.com
-        &ip=1.2.3.4&receiver=localhost
+    authority_explanation=Rejected by SPF record.
     received_spf_header=Received-SPF: fail (example.com: Sender is not
         authorized by default to use 'user@example.com' in 'mfrom' identity
         (mechanism '-all' matched)) receiver=localhost; identity=mfrom;

--- a/bin/spfd
+++ b/bin/spfd
@@ -31,7 +31,7 @@ B<spfd> B<--help>
 
 B<spfd> is a simple forking Sender Policy Framework (SPF) query server.  spfd
 receives and answers SPF requests on a TCP/IP or UNIX domain socket.  For more
-information on SPF see L<http://www.openspf.org>.
+information on SPF see L<https://tools.ietf.org/html/rfc7208>.
 
 The B<--port> form listens on a TCP/IP socket on the specified I<port>.  The
 default port is B<5970>.
@@ -196,8 +196,9 @@ breaks added for clarity):
     result=fail
     local_explanation=example.com: Sender is not authorized by default to use
         'user@example.com' in 'mfrom' identity (mechanism '-all' matched)
-    authority_explanation=Please see http://www.openspf.org/why.html?
-        sender=user%40example.com&ip=1.2.3.4&receiver=localhost
+    authority_explanation=Rejected by SPF record. Please see 
+        http://www.openspf.org/why.html?sender=user%40example.com
+        &ip=1.2.3.4&receiver=localhost
     received_spf_header=Received-SPF: fail (example.com: Sender is not
         authorized by default to use 'user@example.com' in 'mfrom' identity
         (mechanism '-all' matched)) receiver=localhost; identity=mfrom;

--- a/bin/spfquery
+++ b/bin/spfquery
@@ -46,9 +46,10 @@ B<spfquery> B<--help>
 
 =head1 DESCRIPTION
 
-B<spfquery> checks if a given set of e-mail parameters (e.g., the SMTP sender's
+B<spfquery> checks if a given set of e-mail parameters (e.g. the SMTP sender's
 IP address) matches the responsible domain's Sender Policy Framework (SPF)
-policy.  For more information on SPF see L<http://www.openspf.org>.
+policy.  
+For more information on SPF see L<https://tools.ietf.org/html/rfc7208>.
 
 =head2 Preferred Usage
 

--- a/lib/Mail/SPF.pm
+++ b/lib/Mail/SPF.pm
@@ -55,7 +55,8 @@ use constant FALSE  => not TRUE;
 =head1 DESCRIPTION
 
 B<Mail::SPF> is an object-oriented implementation of Sender Policy Framework
-(SPF).  See L<http://www.openspf.org> for more information about SPF.
+(SPF).  See L<https://tools.ietf.org/html/rfc7208> for more information about
+SPF.
 
 This class collection aims to fully conform to the SPF specification (RFC
 4408) so as to serve both as a production quality SPF implementation and as a
@@ -74,11 +75,11 @@ included with Mail::SPF.
 
 =item The SPF project
 
-L<http://www.openspf.org>
+L<http://www.open-spf.org/>
 
-=item The SPFv1 specification (RFC 4408)
+=item The SPFv1 specification (RFC 7208)
 
-L<http://www.openspf.org/Specifications>, L<http://tools.ietf.org/html/rfc4408>
+L<http://www.open-spf.org/Specifications>, L<https://tools.ietf.org/html/rfc7208>
 
 =back
 

--- a/lib/Mail/SPF/Server.pm
+++ b/lib/Mail/SPF/Server.pm
@@ -43,7 +43,7 @@ use constant query_rr_type_txt                      => 1;
 use constant query_rr_type_spf                      => 2;
 
 use constant default_default_authority_explanation  =>
-    'Rejected by SPF record.  Please see http://www.open-spf.org/Why?s=%{_scope};id=%{S};ip=%{C};r=%{R}';
+    'Rejected by SPF record.';
 
 sub default_query_rr_types { shift->query_rr_type_txt };
 
@@ -102,7 +102,7 @@ A I<string> denoting the default (not macro-expanded) authority explanation
 string to use if the authority domain does not specify an explanation string of
 its own.  Defaults to:
 
-    'Rejected by SPF record. Please see http://www.open-spf.org/Why?s=%{_scope};id=%{S};ip=%{C};r=%{R}'
+    'Rejected by SPF record.'
 
 As can be seen from the default, a non-standard C<_scope> pseudo macro is
 supported that expands to the name of the identity's scope.  (Note: Do I<not>

--- a/lib/Mail/SPF/Server.pm
+++ b/lib/Mail/SPF/Server.pm
@@ -43,7 +43,7 @@ use constant query_rr_type_txt                      => 1;
 use constant query_rr_type_spf                      => 2;
 
 use constant default_default_authority_explanation  =>
-    'Please see http://www.openspf.org/Why?s=%{_scope};id=%{S};ip=%{C};r=%{R}';
+    'Rejected by SPF record.  Please see http://www.open-spf.org/Why?s=%{_scope};id=%{S};ip=%{C};r=%{R}';
 
 sub default_query_rr_types { shift->query_rr_type_txt };
 
@@ -102,7 +102,7 @@ A I<string> denoting the default (not macro-expanded) authority explanation
 string to use if the authority domain does not specify an explanation string of
 its own.  Defaults to:
 
-    'Please see http://www.openspf.org/Why?s=%{_scope};id=%{S};ip=%{C};r=%{R}'
+    'Rejected by SPF record. Please see http://www.open-spf.org/Why?s=%{_scope};id=%{S};ip=%{C};r=%{R}'
 
 As can be seen from the default, a non-standard C<_scope> pseudo macro is
 supported that expands to the name of the identity's scope.  (Note: Do I<not>

--- a/lib/Mail/SPF/Util.pm
+++ b/lib/Mail/SPF/Util.pm
@@ -156,8 +156,8 @@ throws I<Mail::SPF::EInvalidOptionValue>
 
 Returns the given I<NetAddr::IP> IPv4 or IPv6 address compactly formatted as a
 I<string>.  For IPv4 addresses, this is equivalent to calling L<NetAddr::IP's
-C<addr> |NetAddr::IP/addr> method.  For IPv6 addresses, this is equivalent to
-calling L<NetAddr::IP's C<short> |NedAddr::IP/short> method.  Throws a
+C<addr>|NetAddr::IP/addr> method.  For IPv6 addresses, this is equivalent to
+calling L<NetAddr::IP's C<short>|NedAddr::IP/short> method.  Throws a
 I<Mail::SPF::EInvalidOptionValue> exception if the specified object is not a
 I<NetAddr::IP> IPv4 or IPv6 address object.
 

--- a/t/rfc4408-tests.yml
+++ b/t/rfc4408-tests.yml
@@ -1,5 +1,5 @@
-# This is the openspf.org test suite (release 2009.10) based on RFC 4408.
-# http://www.openspf.org/Test_Suite
+# This is the open-spf.org test suite (release 2009.10) based on RFC 4408.
+# http://www.open-spf.org/Test_Suite
 #
 # $Id: rfc4408-tests.yml 108 2009-10-31 19:51:18Z Julian Mehnle $
 # vim:sw=2 sts=2 et

--- a/t/rfc7208-tests.yml
+++ b/t/rfc7208-tests.yml
@@ -1,5 +1,5 @@
-# This is the openspf.org test suite (release 2014.04) based on RFC 7208.
-# http://www.openspf.org/Test_Suite
+# This is the open-spf.org test suite (release 2014.04) based on RFC 7208.
+# http://www.open-spf.org/Test_Suite
 #
 # $Id$
 # vim:sw=2 sts=2 et
@@ -2642,7 +2642,7 @@ zonedata:
   _spf.example.com:
     - SPF: "v=spf1 ptr:fe.example.org ptr:sgp.example.com exp=_expspf.example.org -all"
   _expspf.example.org:
-    - TXT: "Sender domain not allowed from this host. Please see http://www.openspf.org/Why?s=mfrom&id=%{S}&ip=%{C}&r=%{R}"
+    - TXT: "Sender domain not allowed from this host. Please see http://www.open-spf.org/Why?s=mfrom&id=%{S}&ip=%{C}&r=%{R}"
   a.example.org:
     - TXT: "Another TXT record."
     - TXT: "v=spf1 ip4:192.0.2.225 ?include:webmail.pair.com ?include:relay.pair.com -all"

--- a/t/rfc7208-tests.yml
+++ b/t/rfc7208-tests.yml
@@ -2642,7 +2642,7 @@ zonedata:
   _spf.example.com:
     - SPF: "v=spf1 ptr:fe.example.org ptr:sgp.example.com exp=_expspf.example.org -all"
   _expspf.example.org:
-    - TXT: "Sender domain not allowed from this host. Please see http://www.open-spf.org/Why?s=mfrom&id=%{S}&ip=%{C}&r=%{R}"
+    - TXT: "Sender domain not allowed from this host."
   a.example.org:
     - TXT: "Another TXT record."
     - TXT: "v=spf1 ip4:192.0.2.225 ?include:webmail.pair.com ?include:relay.pair.com -all"


### PR DESCRIPTION
Merging changes from the Debian patch, (fixes #25) and correcting references from openspf.org to the new open-pf.org