### PR TITLE
Do not check for multiple CNAMEs if the included domain is a macro

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Mail::SPF 3.20250505 -- A Perl implementation of the Sender Policy Framework
+Mail::SPF 3.20240617 -- A Perl implementation of the Sender Policy Framework
 (C) 2005-2013 Julian Mehnle <julian@mehnle.net>
     2005      Shevek <cpan@anarres.org>
 <http://search.cpan.org/dist/Mail-SPF>

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Mail::SPF 3.20240617 -- A Perl implementation of the Sender Policy Framework
+Mail::SPF 3.20250505 -- A Perl implementation of the Sender Policy Framework
 (C) 2005-2013 Julian Mehnle <julian@mehnle.net>
     2005      Shevek <cpan@anarres.org>
 <http://search.cpan.org/dist/Mail-SPF>

--- a/lib/Mail/SPF/Record.pm
+++ b/lib/Mail/SPF/Record.pm
@@ -394,6 +394,8 @@ sub eval {
                 # Term is a mechanism.
                 my $mech = $term;
                 if($term->name eq "include") {
+                  # do not check for CNAMEs if it's a macro
+                  next if $term->{domain_spec}->{text} =~ /%\{/;
                   push(@include_domains, $term->{domain_spec}->{text});
                   if(scalar @include_domains > 1) {
                     foreach my $dom ( @include_domains ) {

--- a/lib/Mail/SPF/Record.pm
+++ b/lib/Mail/SPF/Record.pm
@@ -394,9 +394,17 @@ sub eval {
                 # Term is a mechanism.
                 my $mech = $term;
                 if($term->name eq "include") {
-                  # do not check for CNAMEs if it's a macro
-                  next if $term->{domain_spec}->{text} =~ /%\{/;
-                  push(@include_domains, $term->{domain_spec}->{text});
+                  if($term->{domain_spec}->{text} =~ /%/) {
+                    my $macrostring = Mail::SPF::MacroString->new(
+                       text    => $term->{domain_spec}->{text} ,
+                       server  => $server,
+                       request => $request
+                    );
+                    my $expanded = $macrostring->expand;
+                    push(@include_domains, $expanded);
+                  } else {
+                    push(@include_domains, $term->{domain_spec}->{text});
+                  }
                   if(scalar @include_domains > 1) {
                     foreach my $dom ( @include_domains ) {
                       my $packet;


### PR DESCRIPTION
If the included domain is a macro we should not check it for multiple CNAMEs