### PR TITLE
fix mx limit 10 hops test

### DIFF
--- a/lib/Mail/SPF/Mech/MX.pm
+++ b/lib/Mail/SPF/Mech/MX.pm
@@ -177,9 +177,15 @@ sub match {
     my @mx_rrs        = $mx_packet->answer
         or $server->count_void_dns_lookup($request);
 
-    # Respect the MX mechanism lookups limit (RFC 4408, 5.4/3/4):
-    @mx_rrs = splice(@mx_rrs, 0, $server->max_name_lookups_per_mx_mech)
-        if defined($server->max_name_lookups_per_mx_mech);
+    # RFC 7208 §4.6.4/2: more than 10 MX records is a permerror.
+    if (
+        defined($server->max_name_lookups_per_mx_mech) and
+        @mx_rrs > $server->max_name_lookups_per_mx_mech
+    ) {
+        throw Mail::SPF::EProcessingLimitExceeded(
+            sprintf("Maximum MX look-ups limit (%d) exceeded",
+                    $server->max_name_lookups_per_mx_mech));
+    }
 
     # TODO Use A records from packet's "additional" section?  Probably not.
 

--- a/t/10.00-rfc4408.t
+++ b/t/10.00-rfc4408.t
@@ -9,4 +9,6 @@ plan(skip_all => "Mail::SPF::Test required for testing Mail::SPF's RFC complianc
 
 require('t/Mail-SPF-Test-lib.pm');
 
-run_spf_test_suite_file('t/rfc4408-tests.yml');
+run_spf_test_suite_file('t/rfc4408-tests.yml', {
+    'mx-limit' => 'SKIP: RFC 4408 was ambiguous on this; RFC 7208 clarified it as permerror'
+});

--- a/t/rfc7208-tests.yml
+++ b/t/rfc7208-tests.yml
@@ -2417,18 +2417,18 @@ tests:
     host: 1.2.3.4
     mailfrom: foo@e2.example.com
     result: permerror
-  #mx-limit:
-  #  description: >-
-  #    there MUST be a limit of no more than 10 MX looked up and checked.
-  #  comment: >-
-  #    The required result for this test was the subject of much controversy
-  #    with RFC4408.  For RFC7208 the ambiguity was resolved in favor of
-  #    producing a permerror result.
-  #  spec: 4.6.4/2
-  #  helo: mail.example.com
-  #  host: 1.2.3.5
-  #  mailfrom: foo@e4.example.com
-  #  result: permerror
+  mx-limit:
+    description: >-
+      there MUST be a limit of no more than 10 MX looked up and checked.
+    comment: >-
+      The required result for this test was the subject of much controversy
+      with RFC4408.  For RFC7208 the ambiguity was resolved in favor of
+      producing a permerror result.
+    spec: 4.6.4/2
+    helo: mail.example.com
+    host: 1.2.3.5
+    mailfrom: foo@e4.example.com
+    result: permerror
   ptr-limit:
     description: >-
       there MUST be a limit of no more than 10 PTR looked up and checked.


### PR DESCRIPTION
RFC 7208 is more clear then RFC 4408 on mx hops limit.