### PR TITLE
fix "void lookups" regression test

### DIFF
--- a/t/10.02-rfc7208.t
+++ b/t/10.02-rfc7208.t
@@ -9,4 +9,4 @@ plan(skip_all => "Mail::SPF::Test required for testing Mail::SPF's RFC complianc
 
 require('t/Mail-SPF-Test-lib.pm');
 
-run_spf_test_suite_file('t/rfc7208-tests.yml');
+run_spf_test_suite_file('t/rfc7208-tests.yml', undef, { max_void_dns_lookups => 2 });

--- a/t/Mail-SPF-Test-lib.pm
+++ b/t/Mail-SPF-Test-lib.pm
@@ -10,8 +10,9 @@ use constant FALSE  => not TRUE;
 $Error::Debug = TRUE;
 
 sub run_spf_test_suite_file {
-    my ($file_name, $test_case_overrides) = @_;
+    my ($file_name, $test_case_overrides, $server_opts) = @_;
     $test_case_overrides ||= {};
+    $server_opts = { max_void_dns_lookups => undef, %{$server_opts || {}} };
 
     #### Load Test Suite Data and Plan Tests ####
 
@@ -48,7 +49,7 @@ sub run_spf_test_suite_file {
             ),
             default_authority_explanation
                                     => 'DEFAULT',
-            max_void_dns_lookups    => undef  # Be RFC 4408 compliant during testing!
+            %$server_opts,
         );
 
         foreach my $test_case ($scenario->test_cases) { SKIP: {

--- a/t/rfc7208-tests.yml
+++ b/t/rfc7208-tests.yml
@@ -2514,16 +2514,16 @@ tests:
     host: 1.2.3.4
     mailfrom: foo@e12.example.com
     result: neutral
-  #void-over-limit:
-  #  description: >-
-  #    SPF implementations SHOULD limit "void lookups" to two.  An
-  #    implementation MAY choose to make such a limit configurable.
-  #    In this case, a default of two is RECOMMENDED.
-  #  spec: 4.6.4/7
-  #  helo: mail.example.com
-  #  host: 1.2.3.4
-  #  mailfrom: foo@e11.example.com
-  #  result: permerror
+  void-over-limit:
+    description: >-
+      SPF implementations SHOULD limit "void lookups" to two.  An
+      implementation MAY choose to make such a limit configurable.
+      In this case, a default of two is RECOMMENDED.
+    spec: 4.6.4/7
+    helo: mail.example.com
+    host: 1.2.3.4
+    mailfrom: foo@e11.example.com
+    result: permerror
 zonedata:
   mail.example.com:
     - A: 1.2.3.4


### PR DESCRIPTION
RFC 7208 says that SPF implementations SHOULD limit "void lookups" to 2, fix regression tests