### PR TITLE
Fix SPF record selection to prefer highest version regardless of DNS order

### DIFF
--- a/lib/Mail/SPF/Server.pm
+++ b/lib/Mail/SPF/Server.pm
@@ -486,7 +486,14 @@ sub select_record {
             "No applicable sender policy available");  # RFC 4408, 4.5/7
 
     # Discard all records but the highest acceptable version:
-    my $preferred_record_class = $records[0]->class;
+    my $preferred_record_class;
+    foreach my $version (sort { $b <=> $a } @versions) {
+        my $record_class = $self->record_classes_by_version->{$version};
+        if (grep($_->isa($record_class), @records)) {
+            $preferred_record_class = $record_class;
+            last;
+        }
+    }
     @records = grep($_->isa($preferred_record_class), @records);
 
     @records == 1

--- a/t/rfc4406-tests.yml
+++ b/t/rfc4406-tests.yml
@@ -14,6 +14,15 @@ tests:
     helo: mail.example.com
     host: 1.2.3.4
     mailfrom: foo@v2+v1.example.com
+    result: fai
+  v2-preferred-over-v1-reversed:
+    description: >-
+      "spf2.0" records ought to be preferred over "v=spf1" records
+      regardless of DNS RR order.
+    spec: 4.4/6
+    helo: mail.example.com
+    host: 1.2.3.4
+    mailfrom: foo@v1+v2.example.com
     result: fail
   redundant-v2:
     description: >-
@@ -27,6 +36,9 @@ zonedata:
   v2+v1.example.com:
     - SPF:  spf2.0/mfrom -all
     - SPF:  v=spf1 +all
+  v1+v2.example.com:
+    - SPF:  v=spf1 +all
+    - SPF:  spf2.0/mfrom -all
   v2+v2+v1.example.com:
     - SPF:  spf2.0/mfrom -all
     - SPF:  spf2.0/mfrom,pra -all

--- a/t/rfc4406-tests.yml
+++ b/t/rfc4406-tests.yml
@@ -14,7 +14,7 @@ tests:
     helo: mail.example.com
     host: 1.2.3.4
     mailfrom: foo@v2+v1.example.com
-    result: fai
+    result: fail
   v2-preferred-over-v1-reversed:
     description: >-
       "spf2.0" records ought to be preferred over "v=spf1" records


### PR DESCRIPTION
ail::SPF::Server::select_record() currently determines the preferred
record class from $records[0]. This makes record selection depend on
the order of resource records returned by DNS.

When both a v=spf1 record and an applicable spf2.0/mfrom record are
present, reversing their DNS RR order can therefore change the result.

select_record() already documents that records of the highest
acceptable version should be selected. This change determines the
preferred class from the requested versions instead of from the first
DNS record.

A regression test has also been added with the v=spf1 record appearing
before the spf2.0/mfrom record.

This keeps the existing Sender ID support deterministic without
otherwise changing its behavior.